### PR TITLE
Added quest_definitions table

### DIFF
--- a/migrations/2024-01-22-020556_create_orgs/up.sql
+++ b/migrations/2024-01-22-020556_create_orgs/up.sql
@@ -1,6 +1,6 @@
 -- Your SQL goes here
 CREATE TABLE IF NOT EXISTS orgs
 (
-    org_id   integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    org_name text NOT NULL
+    id   integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    name text NOT NULL
 );

--- a/migrations/2024-01-22-022256_create_claans/up.sql
+++ b/migrations/2024-01-22-022256_create_claans/up.sql
@@ -1,8 +1,8 @@
 -- Your SQL goes here
 CREATE TABLE IF NOT EXISTS claans
 (
-    claan_id   integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    claan_name text NOT NULL,
-    org_id     integer REFERENCES orgs (org_id) ON DELETE CASCADE NOT NULL
+    id     integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    name   text                                           NOT NULL,
+    org_id integer REFERENCES orgs (id) ON DELETE CASCADE NOT NULL
 );
 CREATE INDEX idx_claans_fkeys ON claans(org_id);

--- a/migrations/2024-01-22-022259_create_users/up.sql
+++ b/migrations/2024-01-22-022259_create_users/up.sql
@@ -1,9 +1,9 @@
 -- Your SQL goes here
 CREATE TABLE IF NOT EXISTS users
 (
-    user_id   integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    user_name text NOT NULL,
-    org_id    integer REFERENCES orgs (org_id) ON DELETE CASCADE NOT NULL,
-    claan_id  integer REFERENCES claans (claan_id) ON DELETE SET NULL
+    id       integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    name     text                                           NOT NULL,
+    org_id   integer REFERENCES orgs (id) ON DELETE CASCADE NOT NULL,
+    claan_id integer                                        REFERENCES claans (id) ON DELETE SET NULL
 );
 CREATE INDEX idx_users_fkeys ON users (claan_id, org_id);

--- a/migrations/2024-01-28-004459_quest_definitions/down.sql
+++ b/migrations/2024-01-28-004459_quest_definitions/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS quest_definitions CASCADE

--- a/migrations/2024-01-28-004459_quest_definitions/up.sql
+++ b/migrations/2024-01-28-004459_quest_definitions/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE IF NOT EXISTS quest_definitions
+(
+    id          integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    description text,
+    reward      text                                           NOT NULL,
+    org_id      integer REFERENCES orgs (id) ON DELETE CASCADE NOT NULL
+);
+CREATE INDEX idx_quest_definitions_fkeys ON quest_definitions (org_id);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,31 +1,41 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    claans (claan_id) {
-        claan_id -> Int4,
-        claan_name -> Text,
+    claans (id) {
+        id -> Int4,
+        name -> Text,
         org_id -> Int4,
     }
 }
 
 diesel::table! {
-    orgs (org_id) {
-        org_id -> Int4,
-        org_name -> Text,
+    orgs (id) {
+        id -> Int4,
+        name -> Text,
     }
 }
 
 diesel::table! {
-    users (user_id) {
-        user_id -> Int4,
-        user_name -> Text,
+    quest_definitions (id) {
+        id -> Int4,
+        description -> Nullable<Text>,
+        reward -> Text,
         org_id -> Int4,
-        claan_id -> Int4,
+    }
+}
+
+diesel::table! {
+    users (id) {
+        id -> Int4,
+        name -> Text,
+        org_id -> Int4,
+        claan_id -> Nullable<Int4>,
     }
 }
 
 diesel::joinable!(claans -> orgs (org_id));
+diesel::joinable!(quest_definitions -> orgs (org_id));
 diesel::joinable!(users -> claans (claan_id));
 diesel::joinable!(users -> orgs (org_id));
 
-diesel::allow_tables_to_appear_in_same_query!(claans, orgs, users,);
+diesel::allow_tables_to_appear_in_same_query!(claans, orgs, quest_definitions, users,);


### PR DESCRIPTION
Added new table, `quest_definitions`

```
id (pk)
description
reward
org_id (fk)
```

-----

Also, renamed columns in other tables to be more generic, e.g. `user_id` -> `id` within the Users table.

-----

Closes #4 